### PR TITLE
Allow empty string to be provided

### DIFF
--- a/babbage/query/parser.py
+++ b/babbage/query/parser.py
@@ -25,7 +25,7 @@ class Parser(object):
         self.bindings = []
 
     def string_value(self, ast):
-        text = ast[0]
+        text = ast[0] if len(ast)>0 else ""
         if text.startswith('"') and text.endswith('"'):
             return json.loads(text)
         elif text.startswith('[') and text.endswith(']'):


### PR DESCRIPTION
E.g. to allow this kind of query:
```
?cuts=sector.code:""
```